### PR TITLE
Add a filename as ARGV

### DIFF
--- a/bin/code2pdf
+++ b/bin/code2pdf
@@ -33,7 +33,12 @@ rescue OptionParser::InvalidOption => exception
 end
 
 PATH = ARGV[0].gsub(/\/$/, '')
+if ARGV.size == 1
+  NAME = "_.pdf"
+else
+  NAME = ARGV[1].gsub(/\/$/, '')
+end
 BLACK_LIST_YAML_FILE = "#{PATH}/.code2pdf".freeze
 
-filename = "#{PATH.gsub(/(\.|\/)/, '_')}.pdf"
+filename = "#{PATH.gsub(/(\.|\/)/, NAME)}"
 ConvertToPDF.new from: PATH, to: filename, except: BLACK_LIST_YAML_FILE


### PR DESCRIPTION
J'ai modifié le parseur pour pouvoir spécifier le nom du fichier de sortie.
Après 4 laboratoires, je me suis dit qu'il fallait que je trouve un trouve une alternative pour éviter de renommer les `_.pdf`.